### PR TITLE
fix: adjust rootDir to the project directory.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test": "tsc && jest",
     "verify": "npm run lint && npm run build && npm run coverage && npm run dependency-check",
     "verify-ci": "npm run lint && npm run build && jest --coverage --config jest.config.ci.json && npm run dependency-check",
-    "watch": "jest --watch"
+    "watch": "jest --watch",
+    "semantic-release": "semantic-release"
   },
   "dependencies": {
     "chokidar": "^2.0.4",

--- a/src/append.spec.ts
+++ b/src/append.spec.ts
@@ -1,10 +1,9 @@
 import rimraf from 'rimraf';
-import { ROOT } from './constants';
 import { init, append, load } from '.';
 import { coverageNoPercentage, noCoverage } from './testResultsExamples';
 
 test('create new file', async () => {
-  const rootDir = '.new_file'
+  const rootDir = 'fixtures/new_file'
 
   try {
     init({ rootDir })
@@ -14,13 +13,13 @@ test('create new file', async () => {
     expect(entries.length).toBe(1)
   }
   finally {
-    init({ rootDir: ROOT })
+    init()
     rimraf.sync(rootDir)
   }
 })
 
 test('append to file', async () => {
-  const rootDir = '.append_file'
+  const rootDir = 'fixtures/append_file'
 
   try {
     init({ rootDir })
@@ -31,7 +30,7 @@ test('append to file', async () => {
     expect(entries.length).toBe(2)
   }
   finally {
-    init({ rootDir: ROOT })
+    init()
     rimraf.sync(rootDir)
   }
 })

--- a/src/append.ts
+++ b/src/append.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { unpartial } from 'unpartial';
 import { promisify } from 'util';
 import { compress } from './compress';
-import { TEST_RESULT_FILENAME } from './constants';
+import { TEST_RESULT_FILENAME, PROGRESS_FOLDER } from './constants';
 import { TestResults, FSContext } from './interface';
 import { minify } from './minify';
 import { store } from './store';
@@ -16,7 +16,7 @@ let promisifedAppendFile = promisify(fs.appendFile)
 export async function append(context: Partial<FSContext<'appendFile'>> | undefined, results: TestResults) {
   const c = unpartial<FSContext<'appendFile'>>({ fs, rootDir: store.get().rootDir }, context)
 
-  const filepath = path.join(c.rootDir, TEST_RESULT_FILENAME)
+  const filepath = path.join(c.rootDir, PROGRESS_FOLDER, TEST_RESULT_FILENAME)
   const minified = minify(results)
   const compressed = compress(minified)
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
-export const ROOT = '.progress'
+export const PROGRESS_FOLDER = '.progress'
 export const TEST_RESULT_FILENAME = 'test.results'

--- a/src/init.spec.ts
+++ b/src/init.spec.ts
@@ -1,20 +1,30 @@
 import t from 'assert';
 import fs from 'fs';
 import { init } from './init';
+import { PROGRESS_FOLDER } from './constants';
+import rimraf = require('rimraf');
 
 test('create folder if not exist', () => {
-  t.strictEqual(fs.existsSync('.x'), false)
-  init({ rootDir: '.x' })
-  fs.rmdirSync('.x')
+  try {
+    t.strictEqual(fs.existsSync('fixtures/create-if-not-exist'), false)
+    init({ rootDir: 'fixtures/create-if-not-exist' })
+  }
+  finally {
+    rimraf.sync('fixtures/create-if-not-exist')
+  }
 })
 
 test('ok if folder already existed', () => {
-  fs.mkdirSync('.exist')
-  init({ rootDir: '.exist' })
-  fs.rmdirSync('.exist')
+  try {
+    fs.mkdirSync('fixtures/exist')
+    init({ rootDir: 'fixtures/exist' })
+  }
+  finally {
+    rimraf.sync('fixtures/exist')
+  }
 })
 
 test('by default init will create .progress', () => {
   init()
-  t.strictEqual(fs.existsSync('.progress'), true)
+  t.strictEqual(fs.existsSync(PROGRESS_FOLDER), true)
 })

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,12 +1,13 @@
+import path from 'path'
 import mkdirp from 'mkdirp';
-import { ROOT } from './constants';
+import { PROGRESS_FOLDER } from './constants';
 import { store } from './store';
 
 /**
  * Initialize environment.
  * @param options optional options. Mostly for testing purpose.
  */
-export function init(options = { rootDir: ROOT }) {
-  mkdirp.sync(options.rootDir)
+export function init(options = { rootDir: '.' }) {
+  mkdirp.sync(path.join(options.rootDir, PROGRESS_FOLDER))
   store.set({ rootDir: options.rootDir })
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -2,6 +2,9 @@ import fs from 'fs';
 
 export interface FSContext<FSKeys extends keyof typeof fs> {
   fs: Pick<typeof fs, FSKeys>,
+  /**
+   * Root directory (of the project).
+   */
   rootDir: string
 }
 

--- a/src/load.spec.ts
+++ b/src/load.spec.ts
@@ -3,7 +3,7 @@ import { load } from '.';
 import { store } from './store';
 
 test('not exist', async () => {
-  store.set({ rootDir: 'not-exist' })
+  store.set({ rootDir: 'fixtures/not-exist' })
   const actual = await load(undefined)
   t.strictEqual(actual.length, 0)
 })

--- a/src/load.ts
+++ b/src/load.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { unpartial } from 'unpartial';
 import { decompress } from './compress';
-import { TEST_RESULT_FILENAME } from './constants';
+import { TEST_RESULT_FILENAME, PROGRESS_FOLDER } from './constants';
 import { FSContext, TestResults } from './interface';
 import { unminify } from './minify';
 import { store } from './store';
@@ -14,7 +14,7 @@ let promisifiedReadFile = promisify(fs.readFile)
 export async function load(context?: Partial<FSContext<'readFile'>>) {
   const c = unpartial<FSContext<'readFile'>>({ fs, rootDir: store.get().rootDir }, context)
 
-  const filepath = path.join(c.rootDir, TEST_RESULT_FILENAME)
+  const filepath = path.join(c.rootDir, PROGRESS_FOLDER, TEST_RESULT_FILENAME)
 
   // istanbul ignore next
   if (c.fs.readFile !== readFile) {

--- a/src/monitor.spec.ts
+++ b/src/monitor.spec.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import rimraf from 'rimraf';
 import { append, init, monitor, MonitorSubscription, TestResults } from '.';
-import { ROOT, TEST_RESULT_FILENAME } from './constants';
+import { TEST_RESULT_FILENAME } from './constants';
 import { store } from './store';
 import { filtered, noCoverage } from './testResultsExamples';
 
@@ -26,7 +26,7 @@ test('callback invoked with last save entry initially', async () => {
   }
   finally {
     if (sub) sub.close()
-    init({ rootDir: ROOT })
+    init()
     rimraf.sync(rootDir)
   }
 })
@@ -49,7 +49,7 @@ test('extra empty line in the file is ignored', async () => {
   }
   finally {
     if (sub) sub.close()
-    init({ rootDir: ROOT })
+    init()
     rimraf.sync(rootDir)
   }
 })
@@ -74,7 +74,7 @@ test('callback not invoked when result file not exist', async () => {
   }
   finally {
     if (sub) sub.close()
-    init({ rootDir: ROOT })
+    init()
     rimraf.sync(rootDir)
   }
 })
@@ -90,11 +90,11 @@ test('delete result file should not trigger', async () => {
     const o = new AssertOrder()
     sub = monitor({ rootDir, awaitWriteFinish: { pollInterval: 10, stabilityThreshold: 50 } }, () => o.once(1))
     const filePath = path.join(rootDir, TEST_RESULT_FILENAME)
-    fs.unlinkSync(filePath)
+    rimraf.sync(filePath)
   }
   finally {
     if (sub) sub.close()
-    init({ rootDir: ROOT })
+    init()
     rimraf.sync(rootDir)
   }
 })
@@ -112,7 +112,7 @@ test('trigger on change', async () => {
   }
   finally {
     if (sub) sub.close()
-    init({ rootDir: ROOT })
+    init()
     rimraf.sync(rootDir)
   }
 })
@@ -133,7 +133,7 @@ test('trigger on new file', async () => {
   }
   finally {
     if (sub) sub.close()
-    init({ rootDir: ROOT })
+    init()
     rimraf.sync(rootDir)
   }
 })

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -5,7 +5,7 @@ import readline from 'readline';
 import { Stream } from 'stream';
 import { unpartial } from 'unpartial';
 import { decompress } from './compress';
-import { TEST_RESULT_FILENAME } from './constants';
+import { TEST_RESULT_FILENAME, PROGRESS_FOLDER } from './constants';
 import { TestResults } from './interface';
 import { unminify } from './minify';
 import { store } from './store';
@@ -39,7 +39,7 @@ export function monitor(context: Partial<MonitorContext & GetLastLineContext> | 
     rootDir: store.get().rootDir,
     awaitWriteFinish: true
   }, context)
-  const filepath = path.join(c.rootDir, TEST_RESULT_FILENAME)
+  const filepath = path.join(c.rootDir, PROGRESS_FOLDER, TEST_RESULT_FILENAME)
 
   if (fs.existsSync(filepath))
     invokeCallback(c, filepath, callback)

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,3 @@
 import { create } from 'global-store'
-import { ROOT } from './constants';
 
-export const store = create(Symbol.for('test-progress-tracker'), { rootDir: ROOT })
+export const store = create(Symbol.for('test-progress-tracker'), { rootDir: '.' })


### PR DESCRIPTION
Instead of the path to the `.progress` folder.

This internalize that folder and make it easier to use during init and monitor.