### PR TITLE
fix: add node6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,18 @@ workflows:
   all:
     jobs:
       - node-latest
+      - node10:
+          requires:
+            - node-latest
       - node9:
           requires:
             - node-latest
       - node8:
           requires:
             - node-latest
+      # - node6:
+      #     requires:
+      #       - node-latest
       - release:
           filters:
             branches:
@@ -18,16 +24,17 @@ workflows:
             - node-latest
             - node9
             - node8
+            # - node6
 jobs:
   local-test:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:11
     steps:
       - checkout
       - run: npm run verify
   node-latest:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:11
     steps:
       - checkout
       - restore_cache:
@@ -50,6 +57,17 @@ jobs:
             - node_modules
       - run: npm run verify-ci
       - run: npx codecov
+      - run: npm install --no-save coveralls && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+      - store_test_results:
+          path: .reports/junit
+  node10:
+    docker:
+      - image: 'circleci/node:9'
+    steps:
+      - checkout
+      - attach_workspace:
+          at: '.'
+      - run: npm run verify-ci
       - store_test_results:
           path: .reports/junit
   node9:
@@ -72,9 +90,19 @@ jobs:
       - run: npm run verify-ci
       - store_test_results:
           path: .reports/junit
+  node6:
+    docker:
+      - image: 'circleci/node:8'
+    steps:
+      - checkout
+      - attach_workspace:
+          at: '.'
+      - run: npm run verify-ci
+      - store_test_results:
+          path: .reports/junit
   release:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:11
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
             - node_modules
       - run: npm run verify-ci
       - run: npx codecov
-      - run: npm install --no-save coveralls && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
       - store_test_results:
           path: .reports/junit
   node10:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 notifications:
   email: false
 node_js:
+  - '11'
   - '10'
   - '9'
   - '8'
@@ -16,21 +17,21 @@ branches:
     - master
     - /^greenkeeper.*$/
 
-before_install:
-  - ./scripts/run-on-node-version.sh 10 "npm install -g greenkeeper-lockfile@1"
+# before_install:
+#   - ./scripts/run-on-node-version.sh 10 "npm install -g greenkeeper-lockfile@1"
 
-before_script:
-  - ./scripts/run-on-node-version.sh 10 "greenkeeper-lockfile-update"
+# before_script:
+#   - ./scripts/run-on-node-version.sh 10 "greenkeeper-lockfile-update"
 
 script:
   - npm run verify
 
 after_success:
-  - ./scripts/run-on-node-version.sh 10 "npm install -g coveralls codecov"
-  - npm install -g travis-deploy-once
-  - travis-deploy-once "npm run semantic-release"
-  - ./scripts/run-on-node-version.sh 10 "cat ./coverage/lcov.info | coveralls"
-  - ./scripts/run-on-node-version.sh 10 "codecov"
+  # - ./scripts/run-on-node-version.sh 10 "npm install -g coveralls codecov"
+  # - npm install -g travis-deploy-once
+  # - travis-deploy-once "npm run semantic-release"
+  - ./scripts/run-on-node-version.sh 11 "cat ./coverage/lcov.info | coveralls"
+  # - ./scripts/run-on-node-version.sh 10 "codecov"
 
-after_script:
-  - ./scripts/run-on-node-version.sh 10 "greenkeeper-lockfile-upload"
+# after_script:
+#   - ./scripts/run-on-node-version.sh 10 "greenkeeper-lockfile-upload"

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   'reporters': [
     'default',
-    '@unional/jest-progress-reporter',
+    'jest-progress-tracker',
     ['jest-audio-reporter', { volume: 0.3 }],
   ],
   'roots': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,7 +1626,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -1886,7 +1885,6 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.1.1",
         "function-bind": "^1.1.1",
@@ -1899,7 +1897,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3041,8 +3038,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -3309,7 +3305,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3332,8 +3327,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-value": {
       "version": "1.0.0",
@@ -3633,8 +3627,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "1.2.1",
@@ -3666,8 +3659,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3836,7 +3828,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -3881,7 +3872,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -8839,8 +8829,7 @@
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-      "dev": true
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -8854,7 +8843,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
@@ -11163,7 +11151,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4668,6 +4668,15 @@
       "integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=",
       "dev": true
     },
+    "jest-progress-tracker": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jest-progress-tracker/-/jest-progress-tracker-2.0.1.tgz",
+      "integrity": "sha1-RHB2MW/IqwHwkZwTVpcggHCzdqg=",
+      "dev": true,
+      "requires": {
+        "test-progress-tracker": "^2.0.2"
+      }
+    },
     "jest-regex-util": {
       "version": "23.3.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
@@ -5428,9 +5437,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-stream": {
@@ -10649,6 +10658,18 @@
             "regex-cache": "^0.4.2"
           }
         }
+      }
+    },
+    "test-progress-tracker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/test-progress-tracker/-/test-progress-tracker-2.0.2.tgz",
+      "integrity": "sha1-alSrM5RSJteJR7S/RWulMkwJ3LM=",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.0.4",
+        "global-store": "^0.7.3",
+        "mkdirp": "^0.5.1",
+        "unpartial": "^0.4.1"
       }
     },
     "text-extensions": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "chokidar": "^2.0.4",
     "global-store": "^0.7.3",
     "mkdirp": "^0.5.1",
-    "unpartial": "^0.4.1"
+    "unpartial": "^0.4.1",
+    "util.promisify": "^1.0.0"
   },
   "devDependencies": {
     "@types/chokidar": "^1.7.5",
@@ -51,6 +52,7 @@
     "jest": "^23.6.0",
     "jest-audio-reporter": "^2.2.0",
     "jest-junit": "^5.2.0",
+    "jest-progress-tracker": "^2.0.1",
     "jest-watch-repeat": "^1.0.0",
     "jest-watch-suspend": "^1.1.0",
     "jest-watch-toggle-config": "^1.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import { shim } from 'util.promisify'
+shim()
+
 export * from './append';
 export * from './init';
 export * from './interface';

--- a/src/init.spec.ts
+++ b/src/init.spec.ts
@@ -1,6 +1,6 @@
 import t from 'assert';
 import fs from 'fs';
-import { init } from './init';
+import { init } from '.';
 import { PROGRESS_FOLDER } from './constants';
 import rimraf = require('rimraf');
 


### PR DESCRIPTION
circleci does not have node6 enabled yet due to circular dependency of jest-progress-tracker.

Once published, it can be updated and enable.